### PR TITLE
Add helper for rewriting package.json dependencies on production builds

### DIFF
--- a/filter-deps-for-prod.jq
+++ b/filter-deps-for-prod.jq
@@ -1,0 +1,2 @@
+# Filter-out dev dependencies for production builds
+del(.devDependencies ["@vue/cli-plugin-e2e-cypress", "@vue/cli-plugin-unit-jest", "@types/jest"]) 


### PR DESCRIPTION
Add a jq filter to rewrite development dependencies on a production build. 

This is mainly to avoid downloading heavy E2E testing frameworks (e.g Cypress).