### PR TITLE
Update spatial service

### DIFF
--- a/src/model/catalogue.ts
+++ b/src/model/catalogue.ts
@@ -1,4 +1,4 @@
-import { PageRequest, QueryResultPage } from '@/model/request';
+import { Order, PageRequest, QueryResultPage } from '@/model/request';
 import { ServerResponse } from '@/model/response';
 import { EnumAssetType } from '@/model/enum';
 import { BasePricingModelCommand, EffectivePricingModel } from '@/model/pricing-model';
@@ -49,11 +49,109 @@ export enum EnumDeliveryMethod {
   PHYSICAL_PROVIDER = 'PHYSICAL_PROVIDER',
 }
 
+export enum EnumElasticSearchSortField {
+  TITLE = 'TITLE',
+  REVISION_DATE = 'REVISION_DATE',
+  SCORE = 'SCORE',
+}
+
 export interface CatalogueQuery extends PageRequest {
   /*
    * Query string used for full text search operation
    */
   query: string;
+}
+
+export interface ElasticCatalogueQuery {
+  /**
+   * Full text search
+   */
+  text: string;
+  /**
+   * The nature or genre of the resource
+   */
+  type: EnumAssetType[];
+  /**
+   * The file format, physical medium, or dimensions of the resource e.g. ESRI Shapefile
+   */
+  format: string[];
+  /**
+   * Information about the reference system in automated metadata
+   */
+  crs: string[];
+  /**
+   * Minimum price (excluding VAT)
+   */
+  minPrice: number;
+  /**
+   * Maximum price (excluding VAT)
+   */
+  maxPrice: number;
+  /**
+   * The temporal extent of the resource (start date) with YYYY-MM-DD format e.g. 2020-06-01
+   */
+  fromDate: string;
+  /**
+   * The temporal extent of the resource (end date) with YYYY-MM-DD format e.g. 2020-06-30
+   */
+  toDate: string;
+  /**
+   * A high-level classification scheme to assist in the grouping and topic-based
+   * search of available spatial data resources
+   */
+  topic: EnumTopicCategory[];
+  /**
+   * Minimum scale value
+   */
+  minScale: number;
+  /**
+   * Maximum scale value
+   */
+  maxScale: number;
+  /**
+   * Automated metadata attributes
+   */
+  attribute: string[];
+  /**
+   * Information about resource licensing
+   */
+  license: string[];
+  /**
+   * Name of an entity responsible for making the resource available
+   */
+  publisher: string[];
+  /**
+   * Sorting field
+   */
+  orderBy: EnumElasticSearchSortField;
+  /**
+   * Sorting direction
+   */
+  order: Order;
+  /**
+   * Pagination page index (default: 0)
+   */
+  page: number;
+  /**
+   * Pagination page size (default: 10)
+   */
+  size: number;
+  /**
+   * Bounding box top left longitude
+   */
+  topLeftX: number;
+  /**
+   * Bounding box top left latitude
+   */
+  topLeftY: number;
+  /**
+   * Bounding box bottom right longitude
+   */
+  bottomRightX: number;
+  /**
+   * Bounding box bottom right latitude
+   */
+  bottomRightY: number;
 }
 
 interface Keyword {

--- a/src/service/catalogue.ts
+++ b/src/service/catalogue.ts
@@ -24,11 +24,13 @@ export default class CatalogueApi extends Api {
   }
 
   public async find(query: string | CatalogueQuery, page = 0, size = 10): Promise<CatalogueQueryResponse> {
-    const url = '/action/catalogue';
-
     const data: CatalogueQuery = typeof query === 'string' ? { query, page, size } : query;
 
-    return this.post<CatalogueQuery, CatalogueQueryResponseInternal>(url, data)
+    const params = Object.keys(data).map((k) => `${k}=${params[k]}`);
+
+    const url = `/action/catalogue?${params.join('&')}`;
+
+    return this.get<CatalogueQueryResponseInternal>(url)
       .then((response: AxiosResponse<CatalogueQueryResponseInternal>) => {
         const { data: serverResponse } = response;
 

--- a/src/service/spatial.ts
+++ b/src/service/spatial.ts
@@ -56,10 +56,16 @@ export default class SpatialApi extends Api {
   }
 
   /**
-   * Get all regions by NUTS code prefix (the region for the prefix exact match is not returned)
+   * Get all regions by NUTS code prefix.
+   *
+   * The region for the prefix exact match is not returned.
+   *
+   * @param prefix The prefix to search for
+   * @param maxLevel The max level (inclusive) of the NUTS regions in the result. If not set, all regions are returned
+   * @returns 
    */
-  public async findAllByPrefix(prefix: string): Promise<ServerResponse<NutsRegionFeatureCollection>> {
-    const url = `/action/spatial/nuts/prefix/${prefix}`;
+  public async findAllByPrefix(prefix: string, maxLevel: number | null = null): Promise<ServerResponse<NutsRegionFeatureCollection>> {
+    const url = `/action/spatial/nuts/prefix/${prefix}?maxLevel=${maxLevel === null ? '' : maxLevel}`;
 
     return this.get<ServerResponse<NutsRegionFeatureCollection>>(url)
       .then((response: AxiosServerResponse<NutsRegionFeatureCollection>) => {


### PR DESCRIPTION
Changes:
- When querying NUTS regions by name prefix, optionally filter by max level.
- Added method for querying catalogue items using Elasticsearch.
- Updated catalogue method to match server controller action.

@treecon @thanoseleftherakos 
