### PR TITLE
Fix th:block for googleanalytics tracking code

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,9 +26,9 @@
     <meta name="_csrf" th:content="<%= '${_csrf.token}' %>" />
     <meta name="_csrf_header" th:content="<%= '${_csrf.headerName}' %>" />
     
-    <!-- Inject Thymeleaf block for Google-Analytics tracking code -->
-    <th:block th:if="<%= '${@environment.getProperty(\'opertusmundi.googleanalytics.tracker-id\') != null}' %>">
-      <th:block th:replace="googleanalytics-tracker.html" />
+    <th:block 
+      th:if="<%= '${!#strings.isEmpty(@environment.getProperty(\'opertusmundi.googleanalytics.tracker-id\'))}' %>" 
+      th:insert="googleanalytics-tracker.html :: tracking-code" >
     </th:block>
   </head>
   <body>


### PR DESCRIPTION
Thymeleaf messes up HTML if `th:block` is not closed explicitly (with `</th:block>`)
